### PR TITLE
Maintain order when processing push by wind

### DIFF
--- a/src/main/java/com/codingame/game/Referee.java
+++ b/src/main/java/com/codingame/game/Referee.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.toMap;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -285,7 +286,7 @@ public class Referee extends AbstractReferee {
     }
 
     private void doPush() {
-        Map<GameEntity, List<Vector>> directionMap = new HashMap<>();
+        Map<GameEntity, List<Vector>> directionMap = new LinkedHashMap<>();
 
         for (Hero hero : intentMap.get(ActionType.WIND)) {
             try {


### PR DESCRIPTION
When several monsters are pushed on the same turn, their new position calculation can occur in different order, since we use `HashMap.foreach` . In case monster is pushed out from the base area, the code additionally calculates the new direction based on seeded random. Thus, despite using seeded random, the values from it are applied in different order, resulting in randomly different directions. 

I was able to reproduce it with two equal strategies playing the match. I was getting different matches with same seed. 
But the issue is related to any situation when several monsters are pushed outside the base on the same turn.